### PR TITLE
Upgrade to swift-tools-version:4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:4.0
+
 //
 //  Package.swift
 //  
@@ -9,5 +11,15 @@
 import PackageDescription
 
 let package = Package(
-    name: "USBDeviceSwift"
+    name: "USBDeviceSwift",
+    products: [
+        .library(
+            name: "USBDeviceSwift",
+            targets: ["USBDeviceSwift"]),
+    ],
+    targets: [
+        .target(
+            name: "USBDeviceSwift",
+            path: "Sources"),
+    ]
 )


### PR DESCRIPTION
Previously, the Swift tools version was not specified which meant version 3.1.0 was used as the default. The USBDeviceSwift project is written in Swift 4 which no longer supports this older default version of Swift tools. This resulted in the following error in Xcode when attempting to add USBDeviceSwift as a dependency to a project.

> package at 'https://github.com/Arti3DPlayer/USBDeviceSwift' @ 4f9ce757a1ac6c479c3114e6043d5d4d65458c29 is using Swift tools version 3.1.0 which is no longer supported; consider using '// swift-tools-version:5.1' to specify the current tools version

This change upgrades the Swift tools version used in the Package.swift file to version 4 to resolve the error.
