### PR TITLE
Allow filtering devices by usage page and usage

### DIFF
--- a/Sources/HIDDevice.swift
+++ b/Sources/HIDDevice.swift
@@ -19,10 +19,19 @@ public extension Notification.Name {
 public struct HIDMonitorData {
     public let vendorId:Int
     public let productId:Int
-    
+    public var usagePage:Int?
+    public var usage:Int?
+
     public init (vendorId:Int, productId:Int) {
         self.vendorId = vendorId
         self.productId = productId
+    }
+
+    public init (vendorId:Int, productId:Int, usagePage:Int?, usage:Int?) {
+        self.vendorId = vendorId
+        self.productId = productId
+        self.usagePage = usagePage
+        self.usage = usage
     }
 }
 

--- a/Sources/HIDDeviceMonitor.swift
+++ b/Sources/HIDDeviceMonitor.swift
@@ -24,7 +24,14 @@ open class HIDDeviceMonitor {
         let managerRef = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
         var deviceMatches:[[String:Any]] = []
         for vp in self.vp {
-            deviceMatches.append([kIOHIDProductIDKey: vp.productId, kIOHIDVendorIDKey: vp.vendorId])
+            var match = [kIOHIDProductIDKey: vp.productId, kIOHIDVendorIDKey: vp.vendorId]
+            if let usagePage = vp.usagePage {
+                match[kIOHIDDeviceUsagePageKey] = usagePage
+            }
+            if let usage = vp.usage {
+                match[kIOHIDDeviceUsageKey] = usage
+            }
+            deviceMatches.append(match)
         }
         IOHIDManagerSetDeviceMatchingMultiple(managerRef, deviceMatches as CFArray)
         IOHIDManagerScheduleWithRunLoop(managerRef, CFRunLoopGetCurrent(), CFRunLoopMode.defaultMode.rawValue);


### PR DESCRIPTION
Might be a better idea to instead allow users to pass in a dictionary of [HID Device Property Keys](https://developer.apple.com/documentation/iokit/iohidkeys_h_user-space/hid_device_property_keys) and their values, but this works for me.